### PR TITLE
Fixed Staticman 500 error

### DIFF
--- a/staticman.yml
+++ b/staticman.yml
@@ -101,8 +101,8 @@ comments:
   # Use your OWN siteKey and secret.
   reCaptcha:
     enabled: false
-    siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"
+    siteKey: ""
     # (!) ENCRYPT reCaptcha secret key using Staticman /encrypt endpoint
     # i.e. https://staticman3.herokuapp.com/v3/encrypt/{your-site-secret}
     # For more information, https://staticman.net/docs/encryption
-    secret: "p5uHlH9hCqpMJaGKXdt5MEWFo7K6fX8hoYUwR3aIafOI6rtItLauaDCkGOucysJtrVZy+sHffioGzMsOU64JFDSyPQgrXujegcOHFRXHhD4fOUuBXSvV+OZ8JhSPTGWaRcQcoiGX4pT5hlebLddOl59b6sn6kU1ODQcEbhP83xVLZlaTWOrNrF5Wvy3TMXpH5gyl1tZEORxADAShMYyUbNR7XZYLEg1DfgIBHfIg3cKwdFt7KVLejFGKIiBYRAZDE2JuHItNmzJ2x9JgSK3E+XnShV5tuWpncnyFonJVHGEky/zRfUVLHobDMcJ/u9nlZqE8u47W+833F1WaIYuwNw=="
+    secret: ""


### PR DESCRIPTION
Removed my _own_ site key and secret: https://github.com/daattali/beautiful-jekyll/pull/514#issuecomment-509296996.

If you're _not_ using reCAPTCHA, please either

1. comment out `siteKey` and `secret`; or
2. set them to the empty string `""`

in `staticman.yml`.

* * *

Not related feature request, but I can't raise an issue.  Have you considered using [KaTeX](https://katex.org) for math rendering?